### PR TITLE
Week7

### DIFF
--- a/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
@@ -1,14 +1,11 @@
 package com.kodeco.android.countryinfo.flow
 
-import android.util.Log
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 @OptIn(DelicateCoroutinesApi::class)
@@ -21,6 +18,11 @@ object Flows {
 
     private val _counterFlow = MutableStateFlow(0)
     val counterFlow = _counterFlow.asStateFlow()
+
+    // added combine flow variable, which combines tapFlow and backFlow
+    val combineNavigationFlow = tapFlow.combine(backFlow) { tapFlow, backFlow ->
+        tapFlow + backFlow
+    }
 
     fun tap() {
         _tapFlow.value += 1

--- a/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
@@ -3,7 +3,9 @@ package com.kodeco.android.countryinfo.flow
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
@@ -22,6 +24,10 @@ object Flows {
     // added refresh flow to track how many times screen was refreshed
     private val _refreshFlow = MutableStateFlow(0)
     val refreshFlow = _refreshFlow.asStateFlow()
+
+    // added shared flow to show the toast every time when country row is tapped
+    private val _countryFlow = MutableSharedFlow<String>()
+    val countryFlow = _countryFlow.asSharedFlow()
 
     // added combine flow variable, which combines tapFlow and backFlow
     val combineNavigationFlow = tapFlow.combine(backFlow) { tapFlow, backFlow ->
@@ -46,6 +52,12 @@ object Flows {
                 delay(1_000L)
                 _counterFlow.value += 1
             }
+        }
+    }
+
+    fun triggerSharedFlow(message: String) {
+        GlobalScope.launch {
+            _countryFlow.emit(message)
         }
     }
 }

--- a/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
@@ -1,10 +1,32 @@
 package com.kodeco.android.countryinfo.flow
 
+import android.util.Log
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+@OptIn(DelicateCoroutinesApi::class)
 object Flows {
-    // TODO: Implement the flows here, there should be three public flows:
-    //  1. tapFlow
-    //  2. backFlow
-    //  3. counterFlow
-    //  NOTE: These public flows should be StateFlow<Int> types, you'll need to make separate
-    //  private MutableStateFlow<Int> types that can actually have their values modified.
+    private val _tapFlow = MutableStateFlow(0)
+    val tapFlow = _tapFlow.asStateFlow()
+
+    private val _backFlow = MutableStateFlow(0)
+    val backFlow = _backFlow.asStateFlow()
+
+    private val _counterFlow = MutableStateFlow(0)
+    val counterFlow = _counterFlow.asStateFlow()
+
+    fun tap() {
+        _tapFlow.value += 1
+    }
+
+    fun tapBack() {
+        _backFlow.value += 1
+    }
 }

--- a/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
@@ -29,4 +29,13 @@ object Flows {
     fun tapBack() {
         _backFlow.value += 1
     }
+
+    init {
+        GlobalScope.launch {
+            while (true) {
+                delay(1_000L)
+                _counterFlow.value += 1
+            }
+        }
+    }
 }

--- a/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
@@ -55,7 +55,7 @@ object Flows {
         }
     }
 
-    fun triggerSharedFlow(message: String) {
+    fun triggerCountryFlow(message: String) {
         GlobalScope.launch {
             _countryFlow.emit(message)
         }

--- a/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
@@ -19,6 +19,10 @@ object Flows {
     private val _counterFlow = MutableStateFlow(0)
     val counterFlow = _counterFlow.asStateFlow()
 
+    // added refresh flow to track how many times screen was refreshed
+    private val _refreshFlow = MutableStateFlow(0)
+    val refreshFlow = _refreshFlow.asStateFlow()
+
     // added combine flow variable, which combines tapFlow and backFlow
     val combineNavigationFlow = tapFlow.combine(backFlow) { tapFlow, backFlow ->
         tapFlow + backFlow
@@ -30,6 +34,10 @@ object Flows {
 
     fun tapBack() {
         _backFlow.value += 1
+    }
+
+    fun tapRefresh() {
+        _refreshFlow.value += 1
     }
 
     init {

--- a/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/flow/Flows.kt
@@ -26,8 +26,12 @@ object Flows {
     val refreshFlow = _refreshFlow.asStateFlow()
 
     // added shared flow to show the toast every time when country row is tapped
-    private val _countryFlow = MutableSharedFlow<String>()
-    val countryFlow = _countryFlow.asSharedFlow()
+    private val _countrySharedFlow = MutableSharedFlow<String>()
+    val countrySharedFlow = _countrySharedFlow.asSharedFlow()
+
+    // added shared flow to show the toast every time when refresh button is tapped
+    private val _refreshSharedFlow = MutableSharedFlow<String>()
+    val refreshSharedFlow = _refreshSharedFlow.asSharedFlow()
 
     // added combine flow variable, which combines tapFlow and backFlow
     val combineNavigationFlow = tapFlow.combine(backFlow) { tapFlow, backFlow ->
@@ -55,9 +59,15 @@ object Flows {
         }
     }
 
-    fun triggerCountryFlow(message: String) {
+    fun triggerCountrySharedFlow(message: String) {
         GlobalScope.launch {
-            _countryFlow.emit(message)
+            _countrySharedFlow.emit(message)
+        }
+    }
+
+    fun triggerRefreshSharedFlow(message: String) {
+        GlobalScope.launch {
+            _refreshSharedFlow.emit(message)
         }
     }
 }

--- a/app/src/main/java/com/kodeco/android/countryinfo/network/CountryService.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/network/CountryService.kt
@@ -6,5 +6,5 @@ import retrofit2.http.GET
 
 interface CountryService {
     @GET("all")
-    suspend fun getAllCountries(): Response<List<Country>>
+    suspend fun getAllCountries(): List<Country>
 }

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryDetailsScreen.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryDetailsScreen.kt
@@ -1,8 +1,6 @@
 package com.kodeco.android.countryinfo.ui.components
 
-import android.annotation.SuppressLint
 import androidx.compose.foundation.border
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -26,7 +24,6 @@ import com.kodeco.android.countryinfo.flow.Flows
 import com.kodeco.android.countryinfo.models.Country
 import com.kodeco.android.countryinfo.sample.sampleCountry
 
-@SuppressLint("StateFlowValueCalledInComposition")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CountryDetailsScreen(

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryDetailsScreen.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryDetailsScreen.kt
@@ -1,6 +1,8 @@
 package com.kodeco.android.countryinfo.ui.components
 
+import android.annotation.SuppressLint
 import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material.icons.Icons
@@ -20,9 +22,11 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
+import com.kodeco.android.countryinfo.flow.Flows
 import com.kodeco.android.countryinfo.models.Country
 import com.kodeco.android.countryinfo.sample.sampleCountry
 
+@SuppressLint("StateFlowValueCalledInComposition")
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun CountryDetailsScreen(
@@ -37,7 +41,7 @@ fun CountryDetailsScreen(
                 },
                 navigationIcon = {
                     IconButton(onClick = {
-                        // TODO: Call in to Flows.tapBack()
+                        Flows.tapBack()
                         onNavigateUp()
                     }) {
                         Icon(

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
@@ -1,5 +1,6 @@
 package com.kodeco.android.countryinfo.ui.components
 
+import android.widget.Toast
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -10,6 +11,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -17,6 +19,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -34,9 +37,9 @@ fun CountryInfoList(
     val backCount by Flows.backFlow.collectAsState()
     val refreshCount by Flows.refreshFlow.collectAsState()
     val combineNavigationCount by Flows.combineNavigationFlow.collectAsState(initial = 0)
+    val context = LocalContext.current
 
-    Column(
-    ) {
+    Column {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -72,10 +75,18 @@ fun CountryInfoList(
                 items(countries) { country ->
                     CountryInfoRow(country) {
                         selectedCountry = country
+                        Flows.triggerSharedFlow(country.commonName)
                         Flows.tap()
                     }
                 }
             }
+        }
+    }
+
+    LaunchedEffect(true) {
+        Flows.countryFlow.collect { message ->
+            Toast.makeText(context, "The $message country row was tapped", Toast.LENGTH_SHORT)
+                .show()
         }
     }
 }

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
@@ -3,10 +3,8 @@ package com.kodeco.android.countryinfo.ui.components
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Button
@@ -34,6 +32,7 @@ fun CountryInfoList(
     var selectedCountry: Country? by remember { mutableStateOf(null) }
     val tapCount by Flows.tapFlow.collectAsState()
     val backCount by Flows.backFlow.collectAsState()
+    val combineNavigationCount by Flows.combineNavigationFlow.collectAsState(initial = 0)
 
     Column(
     ) {
@@ -51,6 +50,16 @@ fun CountryInfoList(
                 Text(text = "Refresh")
             }
             Text(text = "Back: $backCount", fontSize = 17.sp)
+        }
+        // Added extra row to display combine flow
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(5.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(text = "Combined navigation: $combineNavigationCount", fontSize = 17.sp)
         }
 
         selectedCountry?.let { country ->

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
@@ -32,13 +32,11 @@ fun CountryInfoList(
     onRefreshClick: () -> Unit, // TODO: Utilize this onRefreshClick
 ) {
     var selectedCountry: Country? by remember { mutableStateOf(null) }
-    val tapCount = Flows.tapFlow.collectAsState(initial = 0)
-    val backCount = Flows.backFlow.collectAsState(initial = 0)
+    val tapCount by Flows.tapFlow.collectAsState()
+    val backCount by Flows.backFlow.collectAsState()
 
     Column(
     ) {
-        // TODO: Implement the Row composable here that contains the
-        //  the tap/back flow data and the refresh button.
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -46,11 +44,11 @@ fun CountryInfoList(
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            Text(text = "Taps: ${tapCount.value}", fontSize = 17.sp)
+            Text(text = "Taps: $tapCount", fontSize = 17.sp)
             Button(onClick = { /*TODO*/ }) {
                 Text(text = "Refresh")
             }
-            Text(text = "Back: ${backCount.value}", fontSize = 17.sp)
+            Text(text = "Back: $backCount", fontSize = 17.sp)
         }
 
         selectedCountry?.let { country ->

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
@@ -20,11 +20,9 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import com.kodeco.android.countryinfo.R
 import com.kodeco.android.countryinfo.flow.Flows
 import com.kodeco.android.countryinfo.models.Country
 import com.kodeco.android.countryinfo.sample.sampleCountries

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
@@ -32,6 +32,7 @@ fun CountryInfoList(
     var selectedCountry: Country? by remember { mutableStateOf(null) }
     val tapCount by Flows.tapFlow.collectAsState()
     val backCount by Flows.backFlow.collectAsState()
+    val refreshCount by Flows.refreshFlow.collectAsState()
     val combineNavigationCount by Flows.combineNavigationFlow.collectAsState(initial = 0)
 
     Column(
@@ -45,13 +46,15 @@ fun CountryInfoList(
         ) {
             Text(text = "Taps: $tapCount", fontSize = 17.sp)
             Button(onClick = {
+                // tracking refresh event here
+                Flows.tapRefresh()
                 onRefreshClick()
             }) {
-                Text(text = "Refresh")
+                Text(text = "Refresh: $refreshCount times")
             }
             Text(text = "Back: $backCount", fontSize = 17.sp)
         }
-        // Added extra row to display combine flow
+        // added extra row to display combine flow
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
@@ -75,7 +75,7 @@ fun CountryInfoList(
                 items(countries) { country ->
                     CountryInfoRow(country) {
                         selectedCountry = country
-                        Flows.triggerSharedFlow(country.commonName)
+                        Flows.triggerCountryFlow(country.commonName)
                         Flows.tap()
                     }
                 }

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
@@ -20,9 +20,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.kodeco.android.countryinfo.R
 import com.kodeco.android.countryinfo.flow.Flows
 import com.kodeco.android.countryinfo.models.Country
 import com.kodeco.android.countryinfo.sample.sampleCountries
@@ -52,6 +54,7 @@ fun CountryInfoList(
                 // tracking refresh event here
                 Flows.tapRefresh()
                 onRefreshClick()
+                Flows.triggerRefreshSharedFlow("The screen is refreshing currently")
             }) {
                 Text(text = "Refresh: $refreshCount times")
             }
@@ -75,7 +78,7 @@ fun CountryInfoList(
                 items(countries) { country ->
                     CountryInfoRow(country) {
                         selectedCountry = country
-                        Flows.triggerCountryFlow(country.commonName)
+                        Flows.triggerCountrySharedFlow(country.commonName)
                         Flows.tap()
                     }
                 }
@@ -84,8 +87,18 @@ fun CountryInfoList(
     }
 
     LaunchedEffect(true) {
-        Flows.countryFlow.collect { message ->
+        Flows.countrySharedFlow.collect { message ->
             Toast.makeText(context, "The $message country row was tapped", Toast.LENGTH_SHORT)
+                .show()
+        }
+    }
+
+    LaunchedEffect(true) {
+        Flows.refreshSharedFlow.collect { message ->
+            Toast.makeText(
+                context,
+                message, Toast.LENGTH_SHORT
+            )
                 .show()
         }
     }

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
@@ -29,7 +29,7 @@ import com.kodeco.android.countryinfo.sample.sampleCountries
 @Composable
 fun CountryInfoList(
     countries: List<Country>,
-    onRefreshClick: () -> Unit, // TODO: Utilize this onRefreshClick
+    onRefreshClick: () -> Unit,
 ) {
     var selectedCountry: Country? by remember { mutableStateOf(null) }
     val tapCount by Flows.tapFlow.collectAsState()
@@ -45,7 +45,9 @@ fun CountryInfoList(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Text(text = "Taps: $tapCount", fontSize = 17.sp)
-            Button(onClick = { /*TODO*/ }) {
+            Button(onClick = {
+                onRefreshClick()
+            }) {
                 Text(text = "Refresh")
             }
             Text(text = "Back: $backCount", fontSize = 17.sp)

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoList.kt
@@ -1,14 +1,28 @@
 package com.kodeco.android.countryinfo.ui.components
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.kodeco.android.countryinfo.flow.Flows
 import com.kodeco.android.countryinfo.models.Country
 import com.kodeco.android.countryinfo.sample.sampleCountries
 
@@ -18,10 +32,26 @@ fun CountryInfoList(
     onRefreshClick: () -> Unit, // TODO: Utilize this onRefreshClick
 ) {
     var selectedCountry: Country? by remember { mutableStateOf(null) }
+    val tapCount = Flows.tapFlow.collectAsState(initial = 0)
+    val backCount = Flows.backFlow.collectAsState(initial = 0)
 
-    Column {
+    Column(
+    ) {
         // TODO: Implement the Row composable here that contains the
         //  the tap/back flow data and the refresh button.
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(5.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(text = "Taps: ${tapCount.value}", fontSize = 17.sp)
+            Button(onClick = { /*TODO*/ }) {
+                Text(text = "Refresh")
+            }
+            Text(text = "Back: ${backCount.value}", fontSize = 17.sp)
+        }
 
         selectedCountry?.let { country ->
             CountryDetailsScreen(country) { selectedCountry = null }
@@ -30,7 +60,7 @@ fun CountryInfoList(
                 items(countries) { country ->
                     CountryInfoRow(country) {
                         selectedCountry = country
-                        // TODO: Call into Flows.tap() here
+                        Flows.tap()
                     }
                 }
             }

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
@@ -44,7 +44,7 @@ fun CountryInfoScreen(
     if (state == CountryInfoState.Loading) {
         LaunchedEffect(key1 = "fetch-countries") {
             getCountryInfoFlow(service)
-                .handleErrors(service)
+                .handleErrors()
                 .collect { newState ->
                     state = newState
                 }
@@ -65,12 +65,12 @@ fun CountryInfoScreenPreview() {
 
 fun getCountryInfoFlow(service: CountryService): Flow<CountryInfoState> = flow {
     val countriesResponse = service.getAllCountries()
-    delay(10000)
+    delay(5000)
     emit(
         CountryInfoState.Success(countriesResponse)
     )
 }
 
-fun <T> Flow<T>.handleErrors(service: CountryService): Flow<T> {
+fun <T> Flow<T>.handleErrors(): Flow<T> {
     return catch { e -> CountryInfoState.Error(e) }
 }

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
@@ -15,8 +15,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
-import retrofit2.Response
-
+t
 sealed class CountryInfoState {
     object Loading : CountryInfoState()
     data class Success(val countries: List<Country>) : CountryInfoState()
@@ -65,7 +64,7 @@ fun CountryInfoScreenPreview() {
 
 fun getCountryInfoFlow(service: CountryService): Flow<CountryInfoState> = flow {
     val countriesResponse = service.getAllCountries()
-    delay(5000)
+    delay(3000)
     emit(
         CountryInfoState.Success(countriesResponse)
     )

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
@@ -15,7 +15,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
-t
+
 sealed class CountryInfoState {
     object Loading : CountryInfoState()
     data class Success(val countries: List<Country>) : CountryInfoState()

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
@@ -11,6 +11,9 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.kodeco.android.countryinfo.models.Country
 import com.kodeco.android.countryinfo.network.CountryService
 import com.kodeco.android.countryinfo.sample.sampleCountries
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flow
 import retrofit2.Response
 
 sealed class CountryInfoState {
@@ -39,21 +42,11 @@ fun CountryInfoScreen(
 
     if (state == CountryInfoState.Loading) {
         LaunchedEffect(key1 = "fetch-countries") {
-            // TODO: Move this to a private method
-            //  and have the method return a Flow<CountryInfoState>
-            //  NOTE: This method can utilize the flow { } builder.
-            //  Don't forget you can also remove the try/catch and catch directly from the flow!
-            state = try {
-                val countriesResponse = service.getAllCountries()
-
-                if (countriesResponse.isSuccessful) {
-                    CountryInfoState.Success(countriesResponse.body()!!)
-                } else {
-                    CountryInfoState.Error(Throwable("Request failed: ${countriesResponse.message()}"))
+            getCountryInfoFlow(service)
+                .handleErrors(service)
+                .collect { newState ->
+                    state = newState
                 }
-            } catch (exception: Exception) {
-                CountryInfoState.Error(exception)
-            }
         }
     }
 }
@@ -63,8 +56,20 @@ fun CountryInfoScreen(
 fun CountryInfoScreenPreview() {
     CountryInfoScreen(
         service = object : CountryService {
-            override suspend fun getAllCountries(): Response<List<Country>> =
-                Response.success(sampleCountries)
+            override suspend fun getAllCountries(): List<Country> =
+                sampleCountries
         },
     )
+}
+
+fun getCountryInfoFlow(service: CountryService): Flow<CountryInfoState> = flow {
+    val countriesResponse = service.getAllCountries()
+    emit(
+        CountryInfoState.Success(countriesResponse)
+
+    )
+}
+
+fun <T> Flow<T>.handleErrors(service: CountryService): Flow<T> {
+    return catch { e -> CountryInfoState.Error(e) }
 }

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/CountryInfoScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.kodeco.android.countryinfo.models.Country
 import com.kodeco.android.countryinfo.network.CountryService
 import com.kodeco.android.countryinfo.sample.sampleCountries
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
@@ -64,9 +65,9 @@ fun CountryInfoScreenPreview() {
 
 fun getCountryInfoFlow(service: CountryService): Flow<CountryInfoState> = flow {
     val countriesResponse = service.getAllCountries()
+    delay(10000)
     emit(
         CountryInfoState.Success(countriesResponse)
-
     )
 }
 

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/Loading.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/Loading.kt
@@ -1,7 +1,5 @@
 package com.kodeco.android.countryinfo.ui.components
 
-import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,15 +12,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.kodeco.android.countryinfo.flow.Flows
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.launch
-import kotlin.concurrent.timer
 
-@SuppressLint("CoroutineCreationDuringComposition", "StateFlowValueCalledInComposition")
 @Composable
 fun Loading() {
     val counter by Flows.counterFlow.collectAsState()
@@ -31,7 +21,6 @@ fun Loading() {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        // TODO: Show the current Flows.counterFlow value here in Text composable
         Text("Current Count: $counter")
         CircularProgressIndicator()
     }

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/Loading.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/Loading.kt
@@ -1,14 +1,28 @@
 package com.kodeco.android.countryinfo.ui.components
 
+import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.kodeco.android.countryinfo.flow.Flows
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlin.concurrent.timer
 
+@OptIn(DelicateCoroutinesApi::class)
+@SuppressLint("CoroutineCreationDuringComposition", "StateFlowValueCalledInComposition")
 @Composable
 fun Loading() {
     Column(
@@ -16,7 +30,6 @@ fun Loading() {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-
         // TODO: Show the current Flows.counterFlow value here in Text composable
         CircularProgressIndicator()
     }

--- a/app/src/main/java/com/kodeco/android/countryinfo/ui/components/Loading.kt
+++ b/app/src/main/java/com/kodeco/android/countryinfo/ui/components/Loading.kt
@@ -9,6 +9,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -21,16 +22,17 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import kotlin.concurrent.timer
 
-@OptIn(DelicateCoroutinesApi::class)
 @SuppressLint("CoroutineCreationDuringComposition", "StateFlowValueCalledInComposition")
 @Composable
 fun Loading() {
+    val counter by Flows.counterFlow.collectAsState()
     Column(
         modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
         // TODO: Show the current Flows.counterFlow value here in Text composable
+        Text("Current Count: $counter")
         CircularProgressIndicator()
     }
 }


### PR DESCRIPTION
- added row with tap, back and refresh buttons
- utilized state flows for tap, back and refresh buttons
- added counter flow to display app runtime(displayed above loading spinner)
- added refreshFlow to track how many times screen was refreshed
- added combineNavigationFlow to validate combined amount of tap and back flows
- added refreshSharedFlow to show the toast every time when refresh button is tapped
- added countrySharedFlow to show the toast every time when country row is tapped